### PR TITLE
Fix case in import `lib/scrollTo` in ResultList.jsx

### DIFF
--- a/source/js/components/Dashboard/ResultView/ResultList.jsx
+++ b/source/js/components/Dashboard/ResultView/ResultList.jsx
@@ -4,7 +4,7 @@ import { List, fromJS } from 'immutable';
 import PropTypes from 'prop-types';
 import Infinite from 'react-infinite';
 import { placeItemHover, placeItemLeave, placeItemSelect } from 'actions/app';
-import scrollTo from 'lib/ScrollTo';
+import scrollTo from 'lib/scrollTo';
 import ResultListItem from './ResultListItem';
 import CityInfo from './CityInfo';
 import DistanceSort from 'worker-loader!workers/distanceSort.js'; //eslint-disable-line


### PR DESCRIPTION
On Linux filesystems, such imports are case-sensitive.

This was failing with
```
Module not found: Error: Can't resolve 'lib/ScrollTo'
in '/code/source/js/components/Dashboard/ResultView'
```